### PR TITLE
Replace "**" with "^" only inside PyBinaryExpression

### DIFF
--- a/src/main/kotlin/ru/meanmail/prettifypython/FoldingBuilder.kt
+++ b/src/main/kotlin/ru/meanmail/prettifypython/FoldingBuilder.kt
@@ -6,6 +6,7 @@ import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.jetbrains.python.psi.PyBinaryExpression
 import com.jetbrains.python.psi.PyStringElement
 
 
@@ -43,6 +44,9 @@ class PrettifyFoldingBuilder : FoldingBuilder {
         val text = node.text
 
         for (entity in prettySymbolMaps.entries) {
+            if (text == "**" && node.parent !is PyBinaryExpression)
+                continue
+
             if (entity.key == text) {
                 val nodeRange = node.textRange
                 val range = TextRange.create(nodeRange.startOffset,


### PR DESCRIPTION
For a long time, I was looking for a plugin like this.

But as for me, there is a little problem with the `**` operator.

In python `**` can be used as a power operator and dict unpacking operator. Currently `prettify-python-plugin` replace them both with `^` sign, but I think only binary power operator should be replaced with `^`.

This is screenshot of a problem menschen above:

![image](https://user-images.githubusercontent.com/32038156/75783938-0d57dd00-5d6a-11ea-96e8-7693e64d50bf.png)

This pull request will replace only a power operator with a `^` sign.

![image](https://user-images.githubusercontent.com/32038156/75784191-7f302680-5d6a-11ea-8c49-800cd553470f.png)
